### PR TITLE
Separate fsrx functionality into a lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
  "atty",
  "bitflags",
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "memchr"
@@ -138,15 +138,15 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "proc-macro-error"
@@ -174,18 +174,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -215,9 +215,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -241,9 +241,9 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,27 @@ readme = "README.md"
 repository = "https://github.com/thatvegandev/fsrx.git"
 homepage = "https://github.com/thatvegandev/fsrx"
 license = "MIT"
-authors = ["Colby Thomas <thatvegandev@gmail.com>"]
+authors = ["Colby Thomas <thatvegandev@gmail.com>", "John Warren <john@thebestjohn.com>"]
 exclude = [".github/*"]
 keywords = ["reading", "utility", "terminal", "cli", "fast"]
+default_features = ["cli"]
+
+[features]
+default = ["cli"]
+cli = ["clap", "atty"]
+
+[lib]
+name = "fsrx_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "fsrx"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [dependencies]
+clap = { version = "3.2.19", features = ["derive"], optional = true}
+atty = { version = "0.2.14", optional = true}
 ansi_term = "0.12.1"
 regex = "1.6.0"
 unicode-segmentation = "1.9.0"
-clap = { version = "3.2.8", features = ["derive"] }
-atty = "0.2.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,96 @@
+use ansi_term::Style;
+use regex::Regex;
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Clone, Debug)]
+pub struct FSRXStyler {
+    pub fixation: f32,
+    pub contrast: bool,
+    pub saccade_mode: usize,
+    saccade_iter: i32,
+    re: Regex,
+}
+
+pub enum Intensity {
+    L, // low
+    M, // medium
+    H, // high
+}
+
+impl FSRXStyler {
+    pub fn new(fixation: Intensity, contrast: bool, saccade_mode: Intensity) -> FSRXStyler {
+        let reg = Regex::new(r"[\w\\']+").unwrap();
+        let mode = match saccade_mode {
+            Intensity::H => 1,
+            Intensity::M => 2,
+            Intensity::L => 3,
+        };
+        let fix = match fixation {
+            Intensity::H => 0.7,
+            Intensity::M => 0.5,
+            Intensity::L => 0.3,
+        };
+        FSRXStyler {
+            fixation: fix,
+            contrast,
+            saccade_mode: mode,
+            saccade_iter: -1,
+            re: reg,
+        }
+    }
+    pub fn style_line(&mut self, unstyled_line: &str) -> String {
+        let mut last_end_idx: usize = 0;
+        let mut styled_line = "".to_owned();
+
+        for reg_match in self.re.find_iter(unstyled_line) {
+            let start_idx = reg_match.start();
+            let end_idx = reg_match.end();
+            styled_line.push_str(
+                self.style_substr(&unstyled_line[last_end_idx..start_idx], false, false)
+                    .as_str(),
+            );
+
+            self.saccade_iter += 1;
+            // println!("{:?}", &self.saccade_iter);
+            let saccade_hit = self.saccade_iter % (self.saccade_mode as i32) == 0;
+            styled_line.push_str(
+                self.style_substr(&unstyled_line[start_idx..end_idx], true, saccade_hit)
+                    .as_str(),
+            );
+            last_end_idx = end_idx;
+        }
+        styled_line.push_str(
+            self.style_substr(
+                &unstyled_line[last_end_idx..unstyled_line.len()],
+                false,
+                false,
+            )
+            .as_str(),
+        );
+        styled_line
+    }
+
+    fn style_substr(&self, substr: &str, should_process: bool, saccade_hit: bool) -> String {
+        let mid_point = (substr.len() as f32 * self.fixation).ceil() as usize;
+        let styled_text = UnicodeSegmentation::graphemes(substr, true)
+            .collect::<Vec<&str>>()
+            .iter()
+            .enumerate()
+            .map(|(i, x)| -> String {
+                let curr_char = x.to_owned();
+                if i < mid_point && saccade_hit && should_process {
+                    if self.contrast {
+                        format!("{}", Style::new().bold().paint(curr_char))
+                    } else {
+                        String::from(curr_char)
+                    }
+                } else {
+                    format!("{}", Style::new().dimmed().paint(curr_char))
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("");
+
+        styled_text
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
-use ansi_term::Style;
-
 use atty::Stream;
 use clap::{ErrorKind, IntoApp, Parser};
-use regex::Regex;
+use fsrx_lib::*;
 use std::{
     fs::File,
     io::{self, BufRead},
     path::Path,
 };
-use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -26,38 +23,41 @@ struct Cli {
     contrast: bool,
 
     /// fixation intensity
-    #[clap(short, long, arg_enum, default_value_t = Intensity::M)]
-    fixation: Intensity,
+    #[clap(short, long, arg_enum, default_value_t = ClapIntensity::M)]
+    fixation: ClapIntensity,
 
     /// saccade intensity
-    #[clap(short, long, arg_enum, default_value_t = Intensity::H)]
-    saccade: Intensity,
+    #[clap(short, long, arg_enum, default_value_t = ClapIntensity::H)]
+    saccade: ClapIntensity,
 }
 
+//This very likely minght be done in a better way, however,
+// the conversion from high level "L, M, H" intensities to their f32 and usize values belongs in the lib
 #[derive(clap::ArgEnum, Clone, Debug)]
-enum Intensity {
-    L, // low
-    M, // medium
-    H, // high
+enum ClapIntensity {
+    L,
+    M,
+    H,
 }
-
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
-    let re = Regex::new(r"[\w\\']+").unwrap();
-    let mut saccade_iter = -1;
-    let saccade_mode = match &cli.saccade {
-        Intensity::H => 1,
-        Intensity::M => 2,
-        Intensity::L => 3,
+    let mode = match cli.saccade {
+        ClapIntensity::H => Intensity::H,
+        ClapIntensity::M => Intensity::M,
+        ClapIntensity::L => Intensity::L,
     };
+    let fix = match cli.fixation {
+        ClapIntensity::H => Intensity::H,
+        ClapIntensity::M => Intensity::M,
+        ClapIntensity::L => Intensity::L,
+    };
+
+    let mut styling: FSRXStyler = FSRXStyler::new(fix, (cli).contrast, mode);
     if cli.path.is_some() {
         if let Ok(lines) = read_lines(cli.path.as_ref().unwrap().as_str()) {
             lines.for_each(|line| {
                 if let Ok(line) = line {
-                    println!(
-                        "{}",
-                        style_line(&line, &re, &cli, &mut saccade_iter, saccade_mode)
-                    );
+                    println!("{}", styling.style_line(&line));
                 }
             });
         } else {
@@ -66,10 +66,7 @@ fn main() -> io::Result<()> {
     } else if !atty::is(Stream::Stdin) {
         io::stdin().lock().lines().for_each(|line| {
             if let Ok(line) = line {
-                println!(
-                    "{}",
-                    style_line(&line, &re, &cli, &mut saccade_iter, saccade_mode)
-                );
+                println!("{}", styling.style_line(&line));
             }
         })
     } else {
@@ -90,71 +87,4 @@ where
 {
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
-}
-
-fn style_line(
-    unstyled_line: &str,
-    re: &Regex,
-    cli: &Cli,
-    saccade_iter: &mut i32,
-    saccade_mode: usize,
-) -> String {
-    let mut last_end_idx: usize = 0;
-    let mut styled_line = "".to_owned();
-
-    for reg_match in re.find_iter(unstyled_line) {
-        let start_idx = reg_match.start();
-        let end_idx = reg_match.end();
-        styled_line.push_str(
-            style_substr(&unstyled_line[last_end_idx..start_idx], cli, false, false).as_str(),
-        );
-
-        *saccade_iter += 1;
-        let saccade_hit = *saccade_iter % (saccade_mode as i32) == 0;
-        styled_line.push_str(
-            style_substr(&unstyled_line[start_idx..end_idx], cli, true, saccade_hit).as_str(),
-        );
-        last_end_idx = end_idx;
-    }
-    styled_line.push_str(
-        style_substr(
-            &unstyled_line[last_end_idx..unstyled_line.len()],
-            cli,
-            false,
-            false,
-        )
-        .as_str(),
-    );
-    styled_line
-}
-
-fn style_substr(substr: &str, cli: &Cli, should_process: bool, saccade_hit: bool) -> String {
-    let mid_point = (substr.len() as f32
-        * match (*cli).fixation {
-            Intensity::H => 0.7,
-            Intensity::M => 0.5,
-            Intensity::L => 0.3,
-        })
-    .ceil() as usize;
-
-    let styled_text = UnicodeSegmentation::graphemes(substr, true)
-        .collect::<Vec<&str>>()
-        .iter()
-        .enumerate()
-        .map(|(i, x)| -> String {
-            let curr_char = x.to_owned();
-            if i < mid_point && saccade_hit && should_process {
-                return if (*cli).contrast {
-                    format!("{}", Style::new().bold().paint(curr_char))
-                } else {
-                    String::from(curr_char)
-                };
-            } else {
-                return format!("{}", Style::new().dimmed().paint(curr_char));
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("");
-
-    styled_text
 }


### PR DESCRIPTION
Add default feature to build bin
Update cli to use fsrx_lib

Bump dependencies

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Migrated the functionality of FSRX into a library that the CLI app uses to mark-up the text. 


**Why**:
Moving fsrx functionality into a library would allow it to be used as a dependency as well to offer the  flow state reading conversion of any text. I was looking to add fsrx into my own fork of the himalaya command line webmail client and, instead of just piping the output to fsrx, I wanted to implement it as an output mode.

Another application would be to quickly make a wasm based browser extension to manipulate `<p>` tags on a website 

<!-- How were these changes implemented? -->

**How**:
I changed `clap` and `atty` to be feature dependent, added the `cli` feature and made it default. 
I then added a lib that provides the `FSRXStyler` struct that maintains contrast, fixation, saccade mode and regex snippet states. 
it provides publicly the `style_line` function which accepts a `&str` and returns a FSRX styled `String`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] `Allow edits from maintainers` option checked
- [x] Branch name is prefixed with `[your_username]/` (ex. `thatvegandev/featureX`)
- [ ] Documentation added
- [ ] Tests added
- [x] No failing actions
- [x] Merge ready
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
